### PR TITLE
fix(auth): guard SSO autologin when route has no project id

### DIFF
--- a/src/app/auth/autologin/autologin.component.ts
+++ b/src/app/auth/autologin/autologin.component.ts
@@ -171,8 +171,9 @@ export class AutologinComponent implements OnInit {
       
       this.logger.log('[AUTOLOGIN] SSO - ssoLogin projectIDGetFromRoute ', projectIDGetFromRoute);
     
-      this.getProject(projectIDGetFromRoute)
-    
+      if (projectIDGetFromRoute != null && typeof projectIDGetFromRoute === 'string' && projectIDGetFromRoute.trim().length > 0) {
+        this.getProject(projectIDGetFromRoute)
+      }
 
       this.router.navigate([route]);
 
@@ -213,11 +214,13 @@ export class AutologinComponent implements OnInit {
       const project_id = route_part[2]
       this.logger.log('[AUTOLOGIN] SSO - ssoLogin route_part ', route_part);
 
-      const storedProjectJson = localStorage.getItem(project_id);
-      this.logger.log('[AUTOLOGIN] SSO - ssoLogin storedProjectJson ', storedProjectJson);
+      if (project_id != null && typeof project_id === 'string' && project_id.trim().length > 0) {
+        const storedProjectJson = localStorage.getItem(project_id);
+        this.logger.log('[AUTOLOGIN] SSO - ssoLogin storedProjectJson ', storedProjectJson);
 
-      if (storedProjectJson === null) {
-        this.getProjectFromRemotePublishAndSaveInStorage(project_id);
+        if (storedProjectJson === null) {
+          this.getProjectFromRemotePublishAndSaveInStorage(project_id);
+        }
       }
     });
   }

--- a/src/app/auth/signin/signin.component.html
+++ b/src/app/auth/signin/signin.component.html
@@ -120,7 +120,7 @@
               </svg>
             </div>
             <div style="padding: 10px 10px 10px 0px; font-weight: 500; width: calc(100% - 91px);">
-              Sign in with OAuth2
+              Sign in with Microsoft
             </div>
             
           </button>

--- a/src/app/core/auth.service.ts
+++ b/src/app/core/auth.service.ts
@@ -1485,9 +1485,25 @@ export class AuthService {
   }
 
   signinWithOAuth2() {
-    const url = this.SERVER_BASE_PATH + 'auth/oauth2'
+    const cfg = this.appConfigService.getConfig()
+    let absoluteDashboardUrl: string
+    if (cfg.oauth2RedirectUrl) {
+      absoluteDashboardUrl = cfg.oauth2RedirectUrl
+    } else {
+      const path = window.location.pathname.replace(/\/$/, '')
+      const prefix = `${window.location.origin}${path}/`
+      if (cfg.defaultProjectId) {
+        absoluteDashboardUrl = `${prefix}#/project/${cfg.defaultProjectId}/home`
+      } else {
+        absoluteDashboardUrl = `${prefix}#/`
+      }
+    }
+    const url =
+      this.SERVER_BASE_PATH +
+      'auth/oauth2?redirect_url=' +
+      encodeURIComponent(absoluteDashboardUrl)
     this.logger.log('[AUTH-SERV] signinWithOAuth2 url ', url)
-    window.open(url, '_self');
+    window.open(url, '_self')
   }
 
 

--- a/src/dashboard-config-template.json
+++ b/src/dashboard-config-template.json
@@ -26,6 +26,8 @@
   "ticketingEmail": "${TICKETING_EMAIL}", 
   "aiModels":"${AI_MODELS}",
   "oauth2SigninEnabled": "${OAUTH2_SIGNIN_ENABLED}",
+  "oauth2RedirectUrl": "${OAUTH2_REDIRECT_URL}",
+  "defaultProjectId": "${DEFAULT_PROJECT_ID}",
   "pineconeReranking":"${PINECONE_RERANKING}",
   "firebase": {
     "apiKey": "${FIREBASE_APIKEY}",

--- a/src/dashboard-config.json
+++ b/src/dashboard-config.json
@@ -26,6 +26,8 @@
   "ticketingEmail": "${TICKETING_EMAIL}", 
   "aiModels":"${AI_MODELS}",
   "oauth2SigninEnabled": "${OAUTH2_SIGNIN_ENABLED}",
+  "oauth2RedirectUrl": "${OAUTH2_REDIRECT_URL}",
+  "defaultProjectId": "${DEFAULT_PROJECT_ID}",
   "pineconeReranking":"${PINECONE_RERANKING}",
   "firebase": {
       "apiKey": "${FIREBASE_APIKEY}",


### PR DESCRIPTION
Made-with: Cursor

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches login/SSO flows by changing how project IDs are derived from routes and how OAuth2 redirect URLs are constructed, which can affect post-login navigation if misconfigured. Scope is small and mostly defensive checks plus config-driven URL building.
> 
> **Overview**
> Prevents SSO autologin from attempting project fetch/storage lookups when the route does not include a valid project id, avoiding `localStorage` access and remote calls with empty/undefined keys.
> 
> Updates OAuth2 sign-in to include a `redirect_url` back to the dashboard, sourced from new config values (`oauth2RedirectUrl`, `defaultProjectId`) or derived from the current origin/path; the sign-in button copy is updated to “Sign in with Microsoft”.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b0fff75f5a986307f209b22ccdc887303a2582bc. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->